### PR TITLE
Avoid aggressively creating sessions.

### DIFF
--- a/src/java/com/granicus/grails/plugins/cookiesession/CookieSessionFilter.java
+++ b/src/java/com/granicus/grails/plugins/cookiesession/CookieSessionFilter.java
@@ -73,9 +73,7 @@ public class CookieSessionFilter extends OncePerRequestFilter implements Initial
       requestWrapper.setSessionPersistenceListeners(this.sessionPersistenceListeners);
       requestWrapper.restoreSession();
 
-      SerializableSession session = (SerializableSession)requestWrapper.getSession();
-
-      SessionRepositoryResponseWrapper responseWrapper = new SessionRepositoryResponseWrapper( response, sessionRepository, session );
+      SessionRepositoryResponseWrapper responseWrapper = new SessionRepositoryResponseWrapper( response, sessionRepository, requestWrapper );
       responseWrapper.setSessionPersistenceListeners(this.sessionPersistenceListeners);
       chain.doFilter(requestWrapper, responseWrapper);
     }

--- a/src/java/com/granicus/grails/plugins/cookiesession/SessionRepositoryResponseWrapper.java
+++ b/src/java/com/granicus/grails/plugins/cookiesession/SessionRepositoryResponseWrapper.java
@@ -34,15 +34,16 @@ public class SessionRepositoryResponseWrapper extends HttpServletResponseWrapper
 
     private String sessionId = "simplesession";
     private SessionRepository sessionRepository;
-    private SerializableSession session;
+    private SessionRepositoryRequestWrapper request;
     private boolean sessionSaved = false;
     private ArrayList<SessionPersistenceListener> sessionPersistenceListeners;
 
     public SessionRepositoryResponseWrapper( HttpServletResponse response, 
-                                              SessionRepository sessionRepository, SerializableSession session) {
+                                              SessionRepository sessionRepository,
+                                              SessionRepositoryRequestWrapper request ) {
       super(response);
       this.sessionRepository = sessionRepository;
-      this.session = session;
+      this.request = request;
     }
 
     public void setSessionPersistenceListeners(ArrayList<SessionPersistenceListener> value){
@@ -63,6 +64,8 @@ public class SessionRepositoryResponseWrapper extends HttpServletResponseWrapper
         if( log.isTraceEnabled() ){ log.trace("session is already saved, not attempting to save again."); }
         return;
       }
+
+      SerializableSession session = (SerializableSession) request.getSession(false);
 
       if( session == null ){
         if( log.isTraceEnabled() ){ log.trace("session is null, not saving."); }


### PR DESCRIPTION
Hello,

my current project involves both UIs with sessions and back-end session-less web services. I would like to avoid creating sessions (and the unneeded cookie exchange) when not necessary. I have modified the code so that it does not create a session upfront. This makes the plugin sessions behave as "classical" sessions.

I have tested the changes with the test-cookie-session-plugin.

Anyway, thanks a lot for this great plugin.

Regards,
Julien
