### PR TITLE
Bump kryo-serializers version to 0.26 to fix ClassCastException's.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,7 +17,7 @@ grails.project.dependency.resolution = {
       //compile 'com.esotericsoftware.kryo:kryo:2.20' 
       //compile 'org.objenesis:objenesis:1.3'
       //NOTE: don't include the above libraries. kryo-serializers has all needed dependencies
-      compile 'de.javakaffee:kryo-serializers:0.23'
+      compile 'de.javakaffee:kryo-serializers:0.26'
     }
 
     plugins {


### PR DESCRIPTION
I was getting ClassCastException's with kryo 0.21 (which kryo-serializers 0.23 depended on); bumping the serializers to 0.26 pulls in kryo 0.22 which solved the issue for me.
