### PR TITLE
Suppport non-ECB cipher modes that require an IV.

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
@@ -33,6 +33,7 @@ import javax.servlet.http.Cookie;
 import java.util.zip.GZIPOutputStream
 import java.util.zip.GZIPInputStream
 
+import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.CipherInputStream
 import javax.crypto.CipherOutputStream
@@ -310,6 +311,17 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
       Cipher cipher = Cipher.getInstance(cryptoAlgorithm)
       cipher.init( Cipher.ENCRYPT_MODE, cryptoKey ) 
       bytes = cipher.doFinal(bytes)
+
+      if( needIV() ){
+        byte[] iv = cipher.getIV()
+
+        byte[] tmp = new byte[1 + iv.length + bytes.length]
+        tmp[0] = iv.length
+        System.arraycopy( iv, 0, tmp, 1, iv.length )
+        System.arraycopy( bytes, 0, tmp, 1 + iv.length, bytes.length )
+
+        bytes = tmp
+      }
     }
 
     log.trace "base64 encoding serialized session from ${bytes.length} bytes"
@@ -332,8 +344,17 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
       if( encryptCookie ){
         log.trace "decrypting serialized session from ${input.length} bytes."
         Cipher cipher = Cipher.getInstance(cryptoAlgorithm)
-        cipher.init( Cipher.DECRYPT_MODE, cryptoKey ) 
-        input = cipher.doFinal(input)
+
+        if( needIV() ){
+          int ivLen = input[0]
+          IvParameterSpec ivSpec = new IvParameterSpec( input, 1, ivLen )
+
+          cipher.init( Cipher.DECRYPT_MODE, cryptoKey, ivSpec )
+          input = cipher.doFinal( input, 1 + ivLen, input.length - 1 - ivLen )
+        } else {
+          cipher.init( Cipher.DECRYPT_MODE, cryptoKey )
+          input = cipher.doFinal(input)
+        }
       }
 
       log.trace "decompressing serialized session from ${input.length} bytes"
@@ -363,6 +384,14 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     log.debug "deserialized session: ${session != null}"
 
     return session 
+  }
+
+  private boolean needIV() {
+    if (cryptoAlgorithm.indexOf('/') < 0)
+      return false      // assuming ECB
+
+    String mode = cryptoAlgorithm.split('/')[1]
+    return (mode.toUpperCase() != 'ECB')
   }
 
   private String[] splitString(String input){


### PR DESCRIPTION
This allows the cipher to be set to things like "Blowfish/CBC/PKCS5Padding", or to other chaining modes that require an IV.

Note that the default of using Blowfish (or any block cipher for that matter) in ECB mode is quite insecure; I would _highly_ recommend the default be changed to "Blowfish/CBC/PKCS5Padding" or similar. However, it would break existing installations that A) don't specify the cipher algorithm explicitly (i.e. rely on the default), and B) have cookies that are expected to survive an update - these would have to make sure to specify the algorithm now.
