### PR TITLE
Fixed exception due to changed package of GrailsUser class in grails spr...

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/KryoSessionSerializer.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/KryoSessionSerializer.groovy
@@ -103,7 +103,7 @@ class KryoSessionSerializer implements SessionSerializer, InitializingBean{
       usernamePasswordAuthenticationTokenClass = grailsApplication.classLoader.loadClass(
         "org.springframework.security.authentication.UsernamePasswordAuthenticationToken")
       grantedAuthorityImplClass = grailsApplication.classLoader.loadClass("org.springframework.security.core.authority.GrantedAuthorityImpl")
-      grailsUserClass = grailsApplication.classLoader.loadClass("org.codehaus.groovy.grails.plugins.springsecurity.GrailsUser")
+      grailsUserClass = grailsApplication.classLoader.loadClass("grails.plugin.springsecurity.userdetails.GrailsUser")
 
       def grantedAuthorityImplSerializer = new GrantedAuthorityImplSerializer()
       grantedAuthorityImplSerializer.targetClass = grantedAuthorityImplClass


### PR DESCRIPTION
Hi Ben

 I found the reason for this plugin not able to work with spring-security 2.0. The package name for the GrailsUser class has changed in the Spring-security-core 2.0. I have changed the package name to the new one in this change. Please validate and integrate. Thanks.
