### PR TITLE
Adding configuration for crypto key size

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ The following parameters are supported directly by the cookie-session-v2 plugin.
       <td>The cryptographic algorithm used to encrypt session data (i.e. Blowfish, DES, DESEde, AES). NOTE: the secret must be compatible with the crypto algorithm. Version 2.0.12 supports non-ECB cipher modes, such as 'Blowfish/CBC/PKCS5Padding', that require an initialization vector</td>
     </tr>
     <tr>
+      <td>grails.plugin.cookiesession.cryptokeysize</td>
+      <td>-unset-</td>
+      <td>The cryptographic key size used by the KeyGenerator. If left unset, SecureRandom will be used to set the key size.</td>
+    </tr>
+    <tr>
       <td>grails.plugin.cookiesession.secret</td>
       <td><b>generated</b></td>
       <td>The secret key used to encrypt session data. If not set, a random key will be created at runtime. Set this parameter if deploying multiple instances of the application or if sessions need to survive a server crash or restart. sessions to be recovered after a server crash or restart.</td>
@@ -187,6 +192,7 @@ Config.groovy
     grails.plugin.cookiesession.enabled = true
     grails.plugin.cookiesession.encryptcookie = true
     grails.plugin.cookiesession.cryptoalgorithm = "Blowfish"
+    grails.plugin.cookiesession.cryptokeysize = 128
     grails.plugin.cookiesession.secret = "This is my secret."
     grails.plugin.cookiesession.cookiecount = 10
     grails.plugin.cookiesession.maxcookiesize = 2048  // 2kb

--- a/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
@@ -58,6 +58,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
   boolean encryptCookie = true
   String cryptoAlgorithm = "Blowfish"
   def cryptoSecret = null
+  int cryptoKeySize = null
   
   long maxInactiveInterval = 120 
 
@@ -163,6 +164,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
 
     assignSettingFromConfig( 'encryptcookie', false, Boolean, 'encryptCookie' )
     assignSettingFromConfig( 'cryptoalgorithm', 'Blowfish', String, 'cryptoAlgorithm' )
+    assignSettingFromConfig( 'cryptokeysize', null, Integer, 'cryptoKeySize' )
     
     def cryptoSecretConfig = grailsApplication.config.grails.plugin.cookiesession.find{ k,v -> k.equalsIgnoreCase('secret') }
     if( cryptoSecretConfig ){
@@ -252,8 +254,12 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     // initialize the crypto key
     if( cryptoSecret == null ){
       def keyGenerator = javax.crypto.KeyGenerator.getInstance( cryptoAlgorithm.split('/')[0] )
-      def secureRandom = new java.security.SecureRandom()
-      keyGenerator.init(secureRandom)
+      if (cryptoKeySize == null) {
+          def secureRandom = new java.security.SecureRandom()
+          keyGenerator.init(secureRandom)
+      } else {
+          keyGenerator.init(cryptoKeySize)
+      }
       cryptoKey = keyGenerator.generateKey()
     }
     else{


### PR DESCRIPTION
We need to ensure the crypto strength of the key size generated. In our
case, we want to ensure we're using AES-256 (Unlimited Strength JCE).

Defaults to the original functionality of using SecureRandom.
