### PR TITLE
ST: removing unused import of hibernate class dependency, fixes tomcat7 ...

### DIFF
--- a/CookieSessionGrailsPlugin.groovy
+++ b/CookieSessionGrailsPlugin.groovy
@@ -25,7 +25,6 @@ import com.granicus.grails.plugins.cookiesession.CookieSessionFilter
 import com.granicus.grails.plugins.cookiesession.CookieSessionRepository
 import com.granicus.grails.plugins.cookiesession.ExceptionCondenser
 import com.granicus.grails.plugins.cookiesession.SecurityContextSessionPersistenceListener
-import org.codehaus.groovy.grails.orm.hibernate.ConfigurableLocalSessionFactoryBean
 
 class CookieSessionGrailsPlugin {
     def version = "2.0.15"


### PR DESCRIPTION
Hi, 

This import of hibernate class dependency is causing an issue with tomcat7 and mongodb plugin. It was giving a class not found exception, solved our issue. 

grails version: 2.3.9
mongo plugin: 3.0.1
