### PR TITLE
Always send set-cookie headers for all cookies.

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
@@ -353,12 +353,8 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
 
     String serializedSession = serializeSession(session) 
    
-    def requestCookieCount = cookieCount
-    if( response instanceof SessionRepositoryResponseWrapper )
-      requestCookieCount = response.request?.cookies?.count{ it.name.startsWith(cookieName) } 
-
     if( session.isValid )
-      putDataInCookie(response, serializedSession, requestCookieCount )
+      putDataInCookie(response, serializedSession )
     else
       deleteCookie(response)
   }
@@ -500,7 +496,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     return data 
   }
 
-  void putDataInCookie(HttpServletResponse response, String value, def requestCookieCount ){
+  void putDataInCookie(HttpServletResponse response, String value ){
     log.trace "putDataInCookie() - ${value.size()}"
 
     // the cookie's maxAge will either be -1 or the number of seconds it should live for
@@ -520,7 +516,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
         response.addCookie(c)
         log.trace "added session ${cookieName}-${i} to response"
       }
-      else if( i < requestCookieCount )
+      else
       {
         // create a delete cookie
         Cookie c = createCookie(i, '', 0) 


### PR DESCRIPTION
Commit 6c44d445a changed things such that set-cookie headers are sent
only for the number of cookies received in the request. This works if
the client sends all requests in strictly sequential order, but fails
if it sends requests in parallel. The following scenario illustrates
this:
 1. the client issues a request and receives 1 set-cookie (gsession-0).
 2. the client issues 2 requests in parallel, each with this one cookie
 3. the first response contains 2 set-cookie headers (gsession-0 and
    gsession-1)
 4. the second response contains 1 set-cookie header (gsession-0).
At this point the client now has 2 cookies, but "mismatched": one from
each response. The next request will fail because the concatenated
result of the two cookies will not be valid.

So, this change reverts the behaviour introduced in the above commit,
and we now always send N set-cookie headers (where N is the configured
max cookie count).