### PR TITLE
Change SPRING_SECURITY_SAVED_REQUEST key

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/SecurityContextSessionPersistenceListener.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/SecurityContextSessionPersistenceListener.groovy
@@ -52,10 +52,10 @@ public class SecurityContextSessionPersistenceListener implements SessionPersist
       
       log.trace session
 
-      if( session.SPRING_SECURITY_SAVED_REQUEST_KEY ){
-        def sessionCookies = session.SPRING_SECURITY_SAVED_REQUEST_KEY.@cookies.findAll{ it.name =~ cookieName }
+      if( session.SPRING_SECURITY_SAVED_REQUEST ){
+        def sessionCookies = session.SPRING_SECURITY_SAVED_REQUEST.@cookies.findAll{ it.name =~ cookieName }
         sessionCookies.each{
-          session.SPRING_SECURITY_SAVED_REQUEST_KEY.@cookies.remove(it)
+          session.SPRING_SECURITY_SAVED_REQUEST.@cookies.remove(it)
         }
       }
 


### PR DESCRIPTION
It's called SPRING_SECURITY_SAVED_REQUEST and not SPRING_SECURITY_SAVED_REQUEST_KEY in latest stable Spring Security plugin 2.0-RC4