### PR TITLE
Log serialized session and request headers when deserialization fails.

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
@@ -311,7 +311,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
       def serializedSession = getDataFromCookie(request)
 
       if( serializedSession ){
-        session = deserializeSession(serializedSession)
+        session = deserializeSession(serializedSession, request)
       }
 
       def maxInactiveIntervalMillis = maxInactiveInterval * 1000;
@@ -399,7 +399,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     return serializedSession
   }
 
-  SerializableSession deserializeSession( String serializedSession ){
+  SerializableSession deserializeSession( String serializedSession, HttpServletRequest request ){
     log.trace "deserializeSession()"
 
     def session = null
@@ -444,6 +444,12 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     }
     catch( excp ){
       log.error "An error occurred while deserializing a session.", excp
+       if( log.isDebugEnabled() )
+         log.debug "Serialized-session: '$serializedSession'\n" +
+                   "request-uri: ${request.requestURI}" +
+                   request.headerNames.toList().inject('') { str, name ->
+                     request.getHeaders(name).inject(str) { str2, val -> "$str2\n$name: $val" }
+                   }
       session = null
     }
 


### PR DESCRIPTION
This has been hugely useful to us in aiding debugging such failures.