### PR TITLE
Throw MaxSizeExceededException instead of raw exception when session max size is exceeded

### DIFF
--- a/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/CookieSessionRepository.groovy
@@ -496,7 +496,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     return data 
   }
 
-  void putDataInCookie(HttpServletResponse response, String value ){
+  void putDataInCookie(HttpServletResponse response, String value ) throws MaxSizeExceededException {
     log.trace "putDataInCookie() - ${value.size()}"
 
     // the cookie's maxAge will either be -1 or the number of seconds it should live for
@@ -505,7 +505,7 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
     if( value.length() > maxCookieSize * cookieCount )
     {
       log.error "Serialized session exceeds maximum session size that can be stored in cookies. Max size: ${maxCookieSize*cookieCount}, Requested Session Size: ${value.length()}."
-      throw new Exception("Serialized session exceeded max size.") 
+      throw new MaxSizeExceededException("Serialized session exceeded max size.")
     }
 
     def partitions = splitString(value)

--- a/src/groovy/com/granicus/grails/plugins/cookiesession/MaxSizeExceededException.groovy
+++ b/src/groovy/com/granicus/grails/plugins/cookiesession/MaxSizeExceededException.groovy
@@ -1,0 +1,7 @@
+package com.granicus.grails.plugins.cookiesession
+
+class MaxSizeExceededException extends Exception {
+    MaxSizeExceededException(String message) {
+        super(message)
+    }
+}


### PR DESCRIPTION
Throwing a particular exception instead of raw exception when session max size is exceeded avoids this workaround if you need to change behavior of CookieSessionRepository extending the base bean:

``` 
    @Override
    void putDataInCookie(HttpServletResponse response, String value) {
        try {
            super.putDataInCookie(response, value)
        } catch (RuntimeException rte) {
            throw rte
        } catch (Exception e) {
            deleteCookie(response)
        }
    } 
```

with

```
    @Override
    void putDataInCookie(HttpServletResponse response, String value) {
        try {
            super.putDataInCookie(response, value)
        } catch (MaxSizeExceededException msee) {
            deleteCookie(response)
        }
    }
```

PD: We Use grails 2.X. This is the cause that the PR goes to 2.0.18 version
